### PR TITLE
Adds method "on" as a synonym to "bind"

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -53,7 +53,7 @@ var asEvented = (function (slice) {
   }
 
   return function () {
-    this.bind = bind;
+    this.bind = this.on = bind;
     this.unbind = unbind;
     this.trigger = trigger;
     this.one = one;

--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -17,6 +17,19 @@ $(function() {
     equals(obj.counter, 5, 'counter should be incremented five times.');
   });
 
+  test("on and trigger", function() {
+    var obj = { counter: 0 };
+    asEvented.call(obj);
+    obj.on('event', function () { obj.counter += 1; });
+    obj.trigger('event');
+    equals(obj.counter, 1, 'counter should be incremented.');
+    obj.trigger('event');
+    obj.trigger('event');
+    obj.trigger('event');
+    obj.trigger('event');
+    equals(obj.counter, 5, 'counter should be incremented five times.');
+  });
+
   test("bind, unbind, trigger", function () {
     var obj = { counter: 0 };
     asEvented.call(obj);


### PR DESCRIPTION
I really love this framework, but would like to use the syntax "object.on('dataLoaded', handleDataLoad)" instead of "object.bind('dataLoaded', handleDataLoad)"

Alternatively I'm considering 'object.when('dataLoaded', handler)' as a way to nudge myself to use past tense for events as opposed to nouns.
