### PR TITLE
Scoped "num" variable to eliminate global.

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -29,7 +29,7 @@ var asEvented = (function (slice) {
   }
 
   function unbind(event, fn) {
-    var events = this.events, eventName, i, parts;
+    var events = this.events, eventName, i, parts, num;
 
     if (!events) return;
 


### PR DESCRIPTION
I believe the "num" variable in the unbind() function isn't supposed to be global.

5 character fix :-)
