### PR TITLE
Modification of behavior when given a callback that does not exist in "unbind".

### DIFF
--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -54,6 +54,19 @@ $(function() {
     equals(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
+  test("unbind non-existent callback", function () {
+    var obj = { counter: 0 };
+    asEvented.call(obj);
+    var callback = function () { obj.counter +=1 };
+    var fakeCallback = function () {};
+    obj.bind('event', callback);
+    obj.trigger('event');
+    equals(obj.counter, 1, 'counter should be incremented.');
+    obj.unbind('event', fakeCallback);
+    obj.trigger('event');
+    equals(obj.counter, 2, 'counter should be incremented twice.');
+  });
+
   test("unbind inside callback", function () {
     var obj = {counter: 0};
     asEvented.call(obj);


### PR DESCRIPTION
Fixed a bug that listener unrelated will be deleted if you give a "non-existent callback" that does not exist in the "unbind"
Fixed a bug that "one" can not delete the callback in the case of msie(<9)

detai:

[one]
  The value of fn and fn1 is not equivalent in the case of the following ie<9
  The code applicable to the case is corrected.
  ======
  var fn = function fn1 () { alert(fn === fn1) } // ie.<9 false

[unbind]
  1) i have modified to be ignored if you give a "non-existent callback" to "unbind"
  2) msie does not have a "Array.indexOf", i made it to the corresponding

[test:unbind]
  add: non-existent callback
