### PR TITLE
Add test case and fix for nested use of .one() function

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -37,8 +37,8 @@
       // [notice] The value of fn and fn1 is not equivalent in the case of the following MSIE.
       // var fn = function fn1 () { alert(fn === fn1) } ie.<9 false
       var fnc = function () {
-        fn.apply(this, slice.call(arguments));
         this.unbind(event, fnc);
+        fn.apply(this, slice.call(arguments));
       };
       this.bind(event, fnc);
       return this;

--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -171,6 +171,27 @@ $(function() {
     equals(obj.count, 3.14, 'obj.count should be PI.');
   });
 
+  test("one nested calls", function () {
+    var obj = { count: 0 };
+    asEvented.call(obj);
+
+    obj.one('event', function() {
+        obj.count += 1;
+
+        obj.one('event', function() {
+            obj.count += 1;
+        });
+
+        // Must be triggered within bound function
+        obj.trigger('event');
+    });
+
+    obj.trigger('event');
+
+    equals(obj.count, 2, 'obj.count should only have been incremented twice.');
+
+  });
+
   test('bind multiple events to one handler', function() {
     var obj = { count: 0 };
     var callback = function() { obj.count += 1; };


### PR DESCRIPTION
This prevents the callback from being run infinitely, by ensuring that the unbind occurs first.
