### PR TITLE
Fix AMD detection condition, as per umdjs/umd/commonjsStrictGlobal.js

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -8,7 +8,7 @@
 (function (name, global, definition) {
   if (typeof module !== 'undefined') {
     module.exports = definition();
-  } else if (typeof require !== 'undefined' && typeof define.amd === 'object') {
+  } else if (typeof define === 'function' && define.amd) {
     define(definition);
   } else {
     global[name] = definition();


### PR DESCRIPTION
This worked fine in the browser using require.js, but I couldn't get it to run in our node test suite until I modified this. This brings the module inline with many other AMD modules and the umdjs examples. See: https://github.com/umdjs/umd/blob/master/commonjsStrictGlobal.js
