### PR TITLE
Prevent multiple bindings of same listener for an event

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -28,7 +28,9 @@
 
       for (i = 0; i < num; i++) {
         events[(part = parts[i])] = events[part] || [];
-        events[part].push(fn);
+        if (_indexOf(events[part], fn) === -1) {
+          events[part].push(fn);
+        }
       }
       return this;
     }

--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -250,4 +250,17 @@ $(function() {
     equals(obj.count, 0, 'obj.count should have been incremented twice.')
   });
 
+  test('bind function multiple times', function() {
+    var obj = { count: 0 };
+    var callback = function() { obj.count += 1; };
+    asEvented.call(obj);
+
+    obj.bind('whatever', callback);
+    obj.bind('whatever', callback);
+
+    obj.trigger('whatever');
+
+    equals(obj.count, 1, 'obj.count should have been incremented once.');
+  });
+
 });


### PR DESCRIPTION
In our use-cases we find it useful to prevent the adding of the same listener function. I'm not sure if it is generally applicable but I'm putting up the pull request for consideration. Thanks for your work!
