### PR TITLE
Do not remove event listener on unbind without callback

### DIFF
--- a/asevented.js
+++ b/asevented.js
@@ -55,7 +55,7 @@
       parts = event.split(/\s+/);
       for (i = 0, num = parts.length; i < num; i++) {
         if ((eventName = parts[i]) in events !== false) {
-          index = (fn) ? _indexOf(events[eventName], fn) : 0;
+          index = (fn) ? _indexOf(events[eventName], fn) : -1;
           if (index !== -1) {
             events[eventName].splice(index, 1);
           }

--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -36,7 +36,7 @@ $(function() {
     var callback = function () { obj.counter += 1; };
     obj.bind('event', callback);
     obj.trigger('event');
-    obj.unbind('event');
+    obj.unbind('event', callback);
     obj.trigger('event');
     equals(obj.counter, 1, 'counter should have only been incremented once.');
   });
@@ -226,7 +226,7 @@ $(function() {
     asEvented.call(obj);
 
     obj.bind('load ready whatever', callback);
-    obj.unbind('ready');
+    obj.unbind('ready', callback);
 
     obj.trigger('load');
     obj.trigger('ready');
@@ -241,7 +241,7 @@ $(function() {
     asEvented.call(obj);
 
     obj.bind('load ready whatever', callback);
-    obj.unbind('ready load whatever');
+    obj.unbind('ready load whatever', callback);
 
     obj.trigger('load');
     obj.trigger('ready');

--- a/test/asevented_test.js
+++ b/test/asevented_test.js
@@ -263,4 +263,16 @@ $(function() {
     equals(obj.count, 1, 'obj.count should have been incremented once.');
   });
 
+  test('unbind without callback', function() {
+    var obj = { count: 0 };
+    var callback = function() { obj.count += 1; };
+    asEvented.call(obj);
+
+    obj.bind('whatever', callback);
+    obj.trigger('whatever');
+    obj.unbind('whatever', undefined);
+    obj.trigger('whatever');
+
+    equals(obj.count, 2, 'obj.count should have been incremented twice.');
+  });
 });


### PR DESCRIPTION
We experienced a bug when trying to remove an event listener without passing a callback function. In this case we expected the library to not remove an event listener, similar to 'removeEventListener'.

The current behaviour is unpredictable because it removes one single (possibly unrelated) listener from the 'events' stack.

As this results in hard to find bugs we changed the behaviour if no callback is passed (so no listener is removed). We adjusted all tests to pass the callback to 'unbind' and added a test scenario for this case.
